### PR TITLE
Refactor Windows injector to get rid of winappdbg dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,23 +100,16 @@ How does *funq* works
   executable called **funq** and a dynamic library **libFunq**. The
   **funq** executable allows to inject some code in a Qt application
   to start a TCP server that will allow to interact with the application.
-  This is currently not working with Python 3 on Windows, but you can still
-  build you application with libFunq as a workaround.
 
 - **funq** is a python package that offers an API to interact with a
   **libFunq** TCP server. It is the client side of the project, and uses
   nosetests to launch FUNctional Qt tests.
 
-Known restrictions
-==================
+Compatibility
+=============
 
-Funq currently works with python >= 2.7 (it is fully compatible with python 3),
-Qt4 and Qt5 on GNU/Linux and macOS.
-
-It also works on Windows, but only with Python 2.7 out of the box. With
-Python 3, the tested application has to be compiled with libFunq because the
-package *winappdbg* (needed for the DLL injection) is not available for Python 3
-(any help welcome!).
+Funq currently works with Python >= 2.7 (it is fully compatible with Python 3),
+Qt4 and Qt5 on GNU/Linux, macOS and Windows.
 
 Documentation
 =============

--- a/server/setup.py
+++ b/server/setup.py
@@ -15,13 +15,6 @@ IS_MAC = platform.system() == 'Darwin'
 
 if sys.version_info < (2, 7):
     sys.exit("Python version must be > 2.7")
-elif sys.version_info > (3,) and IS_WINDOWS:
-    sys.exit('funq server under windows require winappdbg'
-             ' which is not available under python 3 currenly.')
-
-install_requires = []
-if IS_WINDOWS:
-    install_requires.append('winappdbg')
 
 
 def read(*paths):
@@ -145,6 +138,6 @@ setup(
         'install': install,
         'develop': develop,
     },
-    install_requires=install_requires,
+    install_requires=[],
     license='CeCILL v1.2',
 )


### PR DESCRIPTION
See https://github.com/parkouss/funq/pull/74

Created a fork for LibrePCB now so we are no longer blocked until our upstream PRs are accepted. LibrePCB CI can now use the package from this repository instead of the upstream repository.