### PR TITLE
Fix unicode error occuring in setup.py with Python 3

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -10,7 +10,10 @@ if sys.version_info < (2, 7):
 
 def read(*paths):
     this_dir = os.path.dirname(os.path.realpath(__file__))
-    return open(os.path.join(this_dir, *paths)).read()
+    content = open(os.path.join(this_dir, *paths), "rb").read()
+    if sys.version_info < (3, 0):
+        return content  # Do not decode file, since bytes==str in Python 2.x
+    return content.decode("utf-8")
 
 
 version = re.search("__version__ = '(.+)'", read('funq/__init__.py')).group(1)

--- a/server/setup.py
+++ b/server/setup.py
@@ -19,7 +19,10 @@ if sys.version_info < (2, 7):
 
 def read(*paths):
     this_dir = os.path.dirname(os.path.realpath(__file__))
-    return open(os.path.join(this_dir, *paths)).read()
+    content = open(os.path.join(this_dir, *paths), "rb").read()
+    if sys.version_info < (3, 0):
+        return content  # Do not decode file, since bytes==str in Python 2.x
+    return content.decode("utf-8")
 
 
 version = re.search("__version__ = '(.+)'", read('funq_server/__init__.py')).group(1)


### PR DESCRIPTION
With Python 3.6.9 on Ubuntu 18.04, the following error occurs when
installing this package:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-23w3d5em/funq-server/server/setup.py", line 25, in <module>
        version = re.search("__version__ = '(.+)'", read('funq_server/__init__.py')).group(1)
      File "/tmp/pip-build-23w3d5em/funq-server/server/setup.py", line 22, in read
        return open(os.path.join(this_dir, *paths)).read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 72: ordinal not in range(128)

This is fixed when opening the file in binary mode and then converting
the file content to UTF-8.