### PR TITLE
Replace qApp->quit() by qApp->exit()

### DIFF
--- a/client/funq/client.py
+++ b/client/funq/client.py
@@ -158,7 +158,7 @@ class FunqClient(object):
 
     def quit(self):
         """
-        Ask the tested application to quit by calling qApp->quit().
+        Ask the tested application to quit by calling qApp->exit().
         """
         self._raw_send('quit', {})
 
@@ -508,7 +508,7 @@ class ApplicationContext(object):  # pylint: disable=R0903
                     self._process = None
                 else:
                     # try to exit nicely the tested application process
-                    # with a call to qApp->quit().
+                    # with a call to qApp->exit().
                     LOG.info("Closing tested application [%s].",
                              self._process.pid)
                     try:

--- a/doc-dev/server.rst
+++ b/doc-dev/server.rst
@@ -43,7 +43,7 @@ player.cpp:
   
   QtJson::JsonObject Player::quit(const QtJson::JsonObject &) {
       if (qApp) {
-          qApp->quit();
+          qApp->exit();
       }
       QtJson::JsonObject result;
       return result;

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -489,7 +489,7 @@ QtJson::JsonObject Player::widgets_list(const QtJson::JsonObject & command) {
 
 QtJson::JsonObject Player::quit(const QtJson::JsonObject &) {
     if (qApp) {
-        qApp->quit();
+        qApp->exit();
     }
     QtJson::JsonObject result;
     return result;


### PR DESCRIPTION
In Qt6, quit() is not equivalent to exit() anymore and thus the application under test sometimes does not quit anymore.